### PR TITLE
Correct the spelling of CocoaPods in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 [![Build status](https://badge.buildkite.com/aeca41d936ba150f724a0c53831466d1d0377ac34a286b2ee9.svg)](https://buildkite.com/blindingskies/money-fx?branch=development)
 [![codecov.io](https://codecov.io/github/danthorpe/FX/coverage.svg?branch=master)](https://codecov.io/github/danthorpe/FX?branch=development)
-[![Cocoapods Compatible](https://img.shields.io/cocoapods/v/MoneyFX.svg)](https://img.shields.io/cocoapods/v/MoneyFX.svg)
+[![CocoaPods Compatible](https://img.shields.io/cocoapods/v/MoneyFX.svg)](https://img.shields.io/cocoapods/v/MoneyFX.svg)
 [![Carthage compatible](https://img.shields.io/badge/Carthage-compatible-4BC51D.svg?style=flat)](https://github.com/Carthage/Carthage)
 [![Platform](https://img.shields.io/cocoapods/p/MoneyFX.svg?style=flat)](http://cocoadocs.org/docsets/MoneyFX)
 


### PR DESCRIPTION
This pull requests corrects the spelling of **CocoaPods** 🤓
https://github.com/CocoaPods/shared_resources/tree/master/media

<blockquote class="twitter-tweet" data-lang="en"><p lang="en" dir="ltr">One day I’ll make a bot that looks through the READMEs of all Pods, looks to see if it uses “Cocoapods” and PRs “CocoaPods” :D</p>&mdash; Ørta (@orta) <a href="https://twitter.com/orta/status/697374357975388160">February 10, 2016</a></blockquote>

<script async src="//platform.twitter.com/widgets.js" charset="utf-8"></script>
